### PR TITLE
Support optional and default decoding value

### DIFF
--- a/Example.playground/Contents.swift
+++ b/Example.playground/Contents.swift
@@ -2,7 +2,8 @@ import Foundation
 import ForcibleValue
 
 struct User: Decodable {
-    @ForcibleString var name: String
+    @ForcibleString var fullName: String
+    @ForcibleString.Option var nickName: String?
     @ForcibleInt var age: Int
     @ForcibleDouble var height: Double
     @ForcibleFloat var weight: Float
@@ -11,7 +12,7 @@ struct User: Decodable {
 
 let json = """
 {
-    "name": 1234,
+    "fullName": 123,
     "age": "30",
     "height": "172.3",
     "weight": "60.0",
@@ -21,7 +22,7 @@ let json = """
 
 do {
     let user = try JSONDecoder().decode(User.self, from: json!)
-    print(user) // User(_name: 1234, _age: 30, _height: 172.3, _weight: 60.0, _isAdmin: true)
+    print(user) // User(_fullName: 123, _nickName: nil, _age: 30, _height: 172.3, _weight: 60.0, _isAdmin: true)
 } catch {
     print(error)
 }

--- a/Example.playground/Contents.swift
+++ b/Example.playground/Contents.swift
@@ -4,6 +4,7 @@ import ForcibleValue
 struct User: Decodable {
     @ForcibleString var fullName: String
     @ForcibleString.Option var nickName: String?
+    @ForcibleDefault.EmptyString var petName: String
     @ForcibleInt var age: Int
     @ForcibleDouble var height: Double
     @ForcibleFloat var weight: Float
@@ -22,7 +23,7 @@ let json = """
 
 do {
     let user = try JSONDecoder().decode(User.self, from: json!)
-    print(user) // User(_fullName: 123, _nickName: nil, _age: 30, _height: 172.3, _weight: 60.0, _isAdmin: true)
+    print(user) // User(_fullName: 123, _nickName: nil, _petName: "", _age: 30, _height: 172.3, _weight: 60.0, _isAdmin: true)
 } catch {
     print(error)
 }

--- a/README.md
+++ b/README.md
@@ -59,6 +59,69 @@ do {
 }
 ```
 
+### @ForcibleString.Option
+`@ForcibleString.Option` is nil if the Decoder is unable to decode the value, either when nil is encountered or some unexpected type.
+
+`ForcibleBool.Option` and `@ForcibleInt.Option` also have the same behavior, only the type that wraps is different.
+
+```swift
+struct Target: Decodable {
+    @ForcibleString.Option var value1: String?
+    @ForcibleString.Option var value2: String?
+}
+
+let json = #"{ "value1": 1 }"#.data(using: .utf8)!
+let target = try! JSONDecoder().decode(Target.self, from: json)
+
+print(target) // Target(_value1: 1, _value2: nil)
+```
+
+### @ForcibleDefault
+`@ForcibleDefault` provides a generic property wrapper that allows default values using a custom ForcibleDefaultSource protocol.  
+Below are a few common default source.
+
+#### @ForcibleDefault.EmptyString
+`@ForcibleDefault.EmptyString` returns an empty string instead of nil if the Decoder is unable to decode the container. 
+
+```swift
+struct Target: Decodable {
+    @ForcibleDefault.EmptyString var value1: String
+    @ForcibleDefault.EmptyString var value2: String
+}
+
+let json = #"{ "value1": 1 }"#.data(using: .utf8)!
+let target = try! JSONDecoder().decode(Target.self, from: json)
+print(target) // Target(_value1: 1, _value2: )
+```
+
+#### @ForcibleDefault.False
+`@ForcibleDefault.Flase` returns an false instead of nil if the Decoder is unable to decode the container. 
+
+```swift
+struct Target: Decodable {
+    @ForcibleDefault.False var value1: Bool
+    @ForcibleDefault.True var value2: Bool
+}
+
+let json = #"{}"#.data(using: .utf8)!
+let target = try! JSONDecoder().decode(Target.self, from: json)
+print(target) // Target(_value1: false, _value2: true)
+```
+
+#### @ForcibleDefault.Zero
+`@ForcibleDefault.Zero` returns an 0 instead of nil if the Decoder is unable to decode the container.
+
+```swift
+struct Target: Decodable {
+    @ForcibleDefault.Zero var value1: Int
+    @ForcibleDefault.Zero var value2: Int
+}
+
+let json = #"{ "value1": "1" }"#.data(using: .utf8)!
+let target = try! JSONDecoder().decode(Target.self, from: json)
+print(target) // Target(_value1: 1, _value2: 0)
+```
+
 ## Examples
 
 - [Example.playground](https://github.com/to4iki/ForcibleValue/blob/main/Example.playground/Contents.swift)

--- a/Sources/ForcibleValue/Default/ForcibleDefault.swift
+++ b/Sources/ForcibleValue/Default/ForcibleDefault.swift
@@ -1,0 +1,61 @@
+/// Namespace for the default value decoding code
+public enum ForcibleDefault {}
+
+extension ForcibleDefault {
+    @propertyWrapper
+    public struct Wrapper<T: ForcibleDefaultSource>: Decodable, CustomStringConvertible {
+        public typealias Value = T.DefaultValue.Value
+        public var wrappedValue: Value
+
+        public var description: String {
+            wrappedValue.description
+        }
+
+        public init(wrappedValue: Value) {
+            self.wrappedValue = wrappedValue
+        }
+
+        public init(from decoder: Decoder) throws {
+            self.wrappedValue = try T.DefaultValue.init(from: decoder).wrappedValue
+        }
+    }
+}
+
+extension KeyedDecodingContainer {
+    public func decode<T>(_ type: ForcibleDefault.Wrapper<T>.Type, forKey key: Key) throws -> ForcibleDefault.Wrapper<T> where T: ForcibleDefaultSource {
+        try decodeIfPresent(type, forKey: key) ?? .init(wrappedValue: T.defaultValue.wrappedValue)
+    }
+}
+
+extension ForcibleDefault {
+    public typealias EmptyString = Wrapper<Sources.EmptyString>
+    public typealias True = Wrapper<Sources.True>
+    public typealias False = Wrapper<Sources.False>
+    public typealias Zero = Wrapper<Sources.Zero>
+
+    public enum Sources {
+        public enum EmptyString: ForcibleDefaultSource {
+            public static var defaultValue: ForcibleString {
+                .init(wrappedValue: "")
+            }
+        }
+
+        public enum True: ForcibleDefaultSource {
+            public static var defaultValue: ForcibleBool {
+                .init(wrappedValue: true)
+            }
+        }
+
+        public enum False: ForcibleDefaultSource {
+            public static var defaultValue: ForcibleBool {
+                .init(wrappedValue: false)
+            }
+        }
+
+        public enum Zero: ForcibleDefaultSource {
+            public static var defaultValue: ForcibleInt {
+                .init(wrappedValue: 0)
+            }
+        }
+    }
+}

--- a/Sources/ForcibleValue/Default/ForcibleDefaultSource.swift
+++ b/Sources/ForcibleValue/Default/ForcibleDefaultSource.swift
@@ -1,0 +1,5 @@
+///  Generic protocol for default value sources
+public protocol ForcibleDefaultSource {
+    associatedtype DefaultValue: ForcibleValue
+    static var defaultValue: DefaultValue { get }
+}

--- a/Sources/ForcibleValue/ForcibleBool.swift
+++ b/Sources/ForcibleValue/ForcibleBool.swift
@@ -2,7 +2,7 @@
 ///
 /// The values of `Bool`, `Int`, and `String` can be decoded.
 @propertyWrapper
-public struct ForcibleBool: Codable, CustomStringConvertible {
+public struct ForcibleBool: Decodable, CustomStringConvertible {
     public var wrappedValue: Bool
 
     public var description: String {
@@ -53,5 +53,31 @@ public struct ForcibleBool: Codable, CustomStringConvertible {
                 )
             )
         }
+    }
+}
+
+// MARK: - ForcibleBool.Option
+extension ForcibleBool {
+    @propertyWrapper
+    public struct Option: Decodable, CustomStringConvertible {
+        public var wrappedValue: Bool?
+
+        public var description: String {
+            wrappedValue?.description ?? "nil"
+        }
+
+        public init(wrappedValue: Bool?) {
+            self.wrappedValue = wrappedValue
+        }
+
+        public init(from decoder: Decoder) throws {
+            self.wrappedValue = try ForcibleBool(from: decoder).wrappedValue
+        }
+    }
+}
+
+extension KeyedDecodingContainer {
+    public func decode(_ type: ForcibleBool.Option.Type, forKey key: Key) throws -> ForcibleBool.Option {
+        try decodeIfPresent(type, forKey: key) ?? ForcibleBool.Option(wrappedValue: nil)
     }
 }

--- a/Sources/ForcibleValue/ForcibleBool.swift
+++ b/Sources/ForcibleValue/ForcibleBool.swift
@@ -2,7 +2,7 @@
 ///
 /// The values of `Bool`, `Int`, and `String` can be decoded.
 @propertyWrapper
-public struct ForcibleBool: Decodable, CustomStringConvertible {
+public struct ForcibleBool: ForcibleValue {
     public var wrappedValue: Bool
 
     public var description: String {

--- a/Sources/ForcibleValue/ForcibleNumber.swift
+++ b/Sources/ForcibleValue/ForcibleNumber.swift
@@ -2,7 +2,7 @@
 ///
 /// The values of `LosslessStringConvertible` and `String` can be decoded.
 @propertyWrapper
-public struct ForcibleNumber<T: LosslessStringConvertible & Decodable>: Decodable, CustomStringConvertible {
+public struct ForcibleNumber<T: LosslessStringConvertible & Decodable>: ForcibleValue {
     public var wrappedValue: T
 
     public var description: String {

--- a/Sources/ForcibleValue/ForcibleNumber.swift
+++ b/Sources/ForcibleValue/ForcibleNumber.swift
@@ -2,7 +2,7 @@
 ///
 /// The values of `LosslessStringConvertible` and `String` can be decoded.
 @propertyWrapper
-public struct ForcibleNumber<T: LosslessStringConvertible & Codable>: Codable, CustomStringConvertible {
+public struct ForcibleNumber<T: LosslessStringConvertible & Decodable>: Decodable, CustomStringConvertible {
     public var wrappedValue: T
 
     public var description: String {
@@ -42,6 +42,32 @@ public struct ForcibleNumber<T: LosslessStringConvertible & Codable>: Codable, C
     }
 }
 
+// MARK: - ForcibleString.Option
+extension ForcibleNumber {
+    @propertyWrapper
+    public struct Option: Decodable, CustomStringConvertible {
+        public var wrappedValue: T?
+
+        public var description: String {
+            wrappedValue?.description ?? "nil"
+        }
+
+        public init(wrappedValue: T?) {
+            self.wrappedValue = wrappedValue
+        }
+
+        public init(from decoder: Decoder) throws {
+            self.wrappedValue = try ForcibleNumber(from: decoder).wrappedValue
+        }
+    }
+}
+
+extension KeyedDecodingContainer {
+    public func decode<T>(_ type: ForcibleNumber<T>.Option.Type, forKey key: Key) throws -> ForcibleNumber<T>.Option {
+        try decodeIfPresent(type, forKey: key) ?? ForcibleNumber<T>.Option(wrappedValue: nil)
+    }
+}
+
 public typealias ForcibleDouble = ForcibleNumber<Double>
 public typealias ForcibleFloat = ForcibleNumber<Float>
 public typealias ForcibleInt = ForcibleNumber<Int>
@@ -54,3 +80,18 @@ public typealias ForcibleUInt8 = ForcibleNumber<UInt8>
 public typealias ForcibleUInt16 = ForcibleNumber<UInt16>
 public typealias ForcibleUInt32 = ForcibleNumber<UInt32>
 public typealias ForcibleUInt64 = ForcibleNumber<UInt64>
+
+extension ForcibleNumber {
+    public typealias OptionDouble = ForcibleNumber<Double>.Option
+    public typealias OptionFloat = ForcibleNumber<Float>.Option
+    public typealias OptionInt = ForcibleNumber<Int>.Option
+    public typealias OptionInt8 = ForcibleNumber<Int8>.Option
+    public typealias OptionInt16 = ForcibleNumber<Int16>.Option
+    public typealias OptionInt32 = ForcibleNumber<Int32>.Option
+    public typealias OptionInt64 = ForcibleNumber<Int64>.Option
+    public typealias OptionUInt = ForcibleNumber<UInt>.Option
+    public typealias OptionUInt8 = ForcibleNumber<UInt8>.Option
+    public typealias OptionUInt16 = ForcibleNumber<UInt16>.Option
+    public typealias OptionUInt32 = ForcibleNumber<UInt32>.Option
+    public typealias OptionUInt64 = ForcibleNumber<UInt64>.Option
+}

--- a/Sources/ForcibleValue/ForcibleString.swift
+++ b/Sources/ForcibleValue/ForcibleString.swift
@@ -2,7 +2,7 @@
 ///
 /// The values of `String`, `Int`, and `Double` can be decoded.
 @propertyWrapper
-public struct ForcibleString: Decodable, CustomStringConvertible {
+public struct ForcibleString: ForcibleValue {
     public var wrappedValue: String
 
     public var description: String {

--- a/Sources/ForcibleValue/ForcibleString.swift
+++ b/Sources/ForcibleValue/ForcibleString.swift
@@ -2,7 +2,7 @@
 ///
 /// The values of `String`, `Int`, and `Double` can be decoded.
 @propertyWrapper
-public struct ForcibleString: Codable, CustomStringConvertible {
+public struct ForcibleString: Decodable, CustomStringConvertible {
     public var wrappedValue: String
 
     public var description: String {
@@ -31,5 +31,31 @@ public struct ForcibleString: Codable, CustomStringConvertible {
                 )
             )
         }
+    }
+}
+
+// MARK: - ForcibleString.Option
+extension ForcibleString {
+    @propertyWrapper
+    public struct Option: Decodable, CustomStringConvertible {
+        public var wrappedValue: String?
+
+        public var description: String {
+            wrappedValue?.description ?? "nil"
+        }
+
+        public init(wrappedValue: String?) {
+            self.wrappedValue = wrappedValue
+        }
+
+        public init(from decoder: Decoder) throws {
+            self.wrappedValue = try ForcibleString(from: decoder).wrappedValue
+        }
+    }
+}
+
+extension KeyedDecodingContainer {
+    public func decode(_ type: ForcibleString.Option.Type, forKey key: Key) throws -> ForcibleString.Option {
+        try decodeIfPresent(type, forKey: key) ?? ForcibleString.Option(wrappedValue: nil)
     }
 }

--- a/Sources/ForcibleValue/ForcibleValue.swift
+++ b/Sources/ForcibleValue/ForcibleValue.swift
@@ -1,0 +1,5 @@
+///  Generic protocol for Forcible Decode type
+public protocol ForcibleValue: Decodable, CustomStringConvertible {
+    associatedtype Value: Decodable & CustomStringConvertible
+    var wrappedValue: Value { get }
+}

--- a/Tests/ForcibleValueTests/ForcibleBoolTests.swift
+++ b/Tests/ForcibleValueTests/ForcibleBoolTests.swift
@@ -10,6 +10,10 @@ final class ForcibleBoolTests: XCTestCase {
         @ForcibleBool.Option var value: Bool?
     }
 
+    private struct DefaultTarget: Decodable {
+        @ForcibleDefault.False var value: Bool
+    }
+
     func testDecodeSuccess() throws {
         let testCases: [ParameterizedTestCase<Any, Bool>] = [
             .init(input: false, output: false),
@@ -79,6 +83,34 @@ final class ForcibleBoolTests: XCTestCase {
 
             do {
                 let target = try JSONDecoder().decode(OptionTarget.self, from: json!)
+                XCTAssertEqual(target.value, testCase.output)
+            } catch {
+                XCTFail(error.localizedDescription)
+            }
+        }
+    }
+
+    func testDefaultValueDecode() throws {
+        let testCases: [ParameterizedTestCase<Any?, Bool>] = [
+            .init(input: nil, output: false),
+            .init(input: 1, output: true)
+        ]
+
+        for testCase in testCases {
+            let json: Data? = {
+                if let input = testCase.input {
+                    return """
+                    {
+                        "value": \(input)
+                    }
+                    """.data(using: .utf8)
+                } else {
+                    return "{}".data(using: .utf8)
+                }
+            }()
+
+            do {
+                let target = try JSONDecoder().decode(DefaultTarget.self, from: json!)
                 XCTAssertEqual(target.value, testCase.output)
             } catch {
                 XCTFail(error.localizedDescription)

--- a/Tests/ForcibleValueTests/ForcibleBoolTests.swift
+++ b/Tests/ForcibleValueTests/ForcibleBoolTests.swift
@@ -6,6 +6,10 @@ final class ForcibleBoolTests: XCTestCase {
         @ForcibleBool var value: Bool
     }
 
+    private struct OptionTarget: Decodable {
+        @ForcibleBool.Option var value: Bool?
+    }
+
     func testDecodeSuccess() throws {
         let testCases: [ParameterizedTestCase<Any, Bool>] = [
             .init(input: false, output: false),
@@ -13,7 +17,7 @@ final class ForcibleBoolTests: XCTestCase {
             .init(input: 0, output: false),
             .init(input: 1, output: true),
             .init(input: "\"false\"", output: false),
-            .init(input: "\"true\"", output: true),
+            .init(input: "\"true\"", output: true)
         ]
 
         for testCase in testCases {
@@ -51,6 +55,34 @@ final class ForcibleBoolTests: XCTestCase {
             XCTAssertThrowsError(
                 try JSONDecoder().decode(Target.self, from: json!)
             )
+        }
+    }
+
+    func testOptionDecode() throws {
+        let testCases: [ParameterizedTestCase<Any?, Bool?>] = [
+            .init(input: nil, output: nil),
+            .init(input: 0, output: false)
+        ]
+
+        for testCase in testCases {
+            let json: Data? = {
+                if let input = testCase.input {
+                    return """
+                    {
+                        "value": \(input)
+                    }
+                    """.data(using: .utf8)
+                } else {
+                    return "{}".data(using: .utf8)
+                }
+            }()
+
+            do {
+                let target = try JSONDecoder().decode(OptionTarget.self, from: json!)
+                XCTAssertEqual(target.value, testCase.output)
+            } catch {
+                XCTFail(error.localizedDescription)
+            }
         }
     }
 }

--- a/Tests/ForcibleValueTests/ForcibleNumberTests.swift
+++ b/Tests/ForcibleValueTests/ForcibleNumberTests.swift
@@ -6,6 +6,10 @@ final class ForcibleNumberTests: XCTestCase {
         @ForcibleInt var value: Int
     }
 
+    private struct OptionTarget: Decodable {
+        @ForcibleInt.Option var value: Int?
+    }
+
     func testDecodeSuccess() throws {
         let testCases: [ParameterizedTestCase<Any, Int>] = [
             .init(input: 1, output: 1),
@@ -43,6 +47,34 @@ final class ForcibleNumberTests: XCTestCase {
             XCTAssertThrowsError(
                 try JSONDecoder().decode(Target.self, from: json!)
             )
+        }
+    }
+
+    func testOptionDecode() throws {
+        let testCases: [ParameterizedTestCase<Any?, Int?>] = [
+            .init(input: nil, output: nil),
+            .init(input: "\"1\"", output: 1)
+        ]
+
+        for testCase in testCases {
+            let json: Data? = {
+                if let input = testCase.input {
+                    return """
+                    {
+                        "value": \(input)
+                    }
+                    """.data(using: .utf8)
+                } else {
+                    return "{}".data(using: .utf8)
+                }
+            }()
+
+            do {
+                let target = try JSONDecoder().decode(OptionTarget.self, from: json!)
+                XCTAssertEqual(target.value, testCase.output)
+            } catch {
+                XCTFail(error.localizedDescription)
+            }
         }
     }
 }

--- a/Tests/ForcibleValueTests/ForcibleNumberTests.swift
+++ b/Tests/ForcibleValueTests/ForcibleNumberTests.swift
@@ -10,6 +10,10 @@ final class ForcibleNumberTests: XCTestCase {
         @ForcibleInt.Option var value: Int?
     }
 
+    private struct DefaultTarget: Decodable {
+        @ForcibleDefault.Zero var value: Int
+    }
+
     func testDecodeSuccess() throws {
         let testCases: [ParameterizedTestCase<Any, Int>] = [
             .init(input: 1, output: 1),
@@ -71,6 +75,34 @@ final class ForcibleNumberTests: XCTestCase {
 
             do {
                 let target = try JSONDecoder().decode(OptionTarget.self, from: json!)
+                XCTAssertEqual(target.value, testCase.output)
+            } catch {
+                XCTFail(error.localizedDescription)
+            }
+        }
+    }
+
+    func testDefaultValueDecode() throws {
+        let testCases: [ParameterizedTestCase<Any?, Int>] = [
+            .init(input: nil, output: 0),
+            .init(input: "\"1\"", output: 1)
+        ]
+
+        for testCase in testCases {
+            let json: Data? = {
+                if let input = testCase.input {
+                    return """
+                    {
+                        "value": \(input)
+                    }
+                    """.data(using: .utf8)
+                } else {
+                    return "{}".data(using: .utf8)
+                }
+            }()
+
+            do {
+                let target = try JSONDecoder().decode(DefaultTarget.self, from: json!)
                 XCTAssertEqual(target.value, testCase.output)
             } catch {
                 XCTFail(error.localizedDescription)

--- a/Tests/ForcibleValueTests/ForcibleStringTests.swift
+++ b/Tests/ForcibleValueTests/ForcibleStringTests.swift
@@ -6,11 +6,15 @@ final class ForcibleStringTests: XCTestCase {
         @ForcibleString var value: String
     }
 
+    private struct OptionTarget: Decodable {
+        @ForcibleString.Option var value: String?
+    }
+
     func testDecodeSuccess() throws {
         let testCases: [ParameterizedTestCase<Any, String>] = [
             .init(input: "\"string\"", output: "string"),
             .init(input: 1, output: "1"),
-            .init(input: 1.1, output: "1.1"),
+            .init(input: 1.1, output: "1.1")
         ]
 
         for testCase in testCases {
@@ -45,6 +49,34 @@ final class ForcibleStringTests: XCTestCase {
             XCTAssertThrowsError(
                 try JSONDecoder().decode(Target.self, from: json!)
             )
+        }
+    }
+
+    func testOptionDecode() throws {
+        let testCases: [ParameterizedTestCase<Any?, String?>] = [
+            .init(input: nil, output: nil),
+            .init(input: 1, output: "1")
+        ]
+
+        for testCase in testCases {
+            let json: Data? = {
+                if let input = testCase.input {
+                    return """
+                    {
+                        "value": \(input)
+                    }
+                    """.data(using: .utf8)
+                } else {
+                    return "{}".data(using: .utf8)
+                }
+            }()
+
+            do {
+                let target = try JSONDecoder().decode(OptionTarget.self, from: json!)
+                XCTAssertEqual(target.value, testCase.output)
+            } catch {
+                XCTFail(error.localizedDescription)
+            }
         }
     }
 }

--- a/Tests/ForcibleValueTests/ForcibleStringTests.swift
+++ b/Tests/ForcibleValueTests/ForcibleStringTests.swift
@@ -10,6 +10,10 @@ final class ForcibleStringTests: XCTestCase {
         @ForcibleString.Option var value: String?
     }
 
+    private struct DefaultTarget: Decodable {
+        @ForcibleDefault.EmptyString var value: String
+    }
+
     func testDecodeSuccess() throws {
         let testCases: [ParameterizedTestCase<Any, String>] = [
             .init(input: "\"string\"", output: "string"),
@@ -73,6 +77,34 @@ final class ForcibleStringTests: XCTestCase {
 
             do {
                 let target = try JSONDecoder().decode(OptionTarget.self, from: json!)
+                XCTAssertEqual(target.value, testCase.output)
+            } catch {
+                XCTFail(error.localizedDescription)
+            }
+        }
+    }
+
+    func testDefaultValueDecode() throws {
+        let testCases: [ParameterizedTestCase<Any?, String>] = [
+            .init(input: nil, output: ""),
+            .init(input: 1, output: "1"),
+        ]
+
+        for testCase in testCases {
+            let json: Data? = {
+                if let input = testCase.input {
+                    return """
+                    {
+                        "value": \(input)
+                    }
+                    """.data(using: .utf8)
+                } else {
+                    return "{}".data(using: .utf8)
+                }
+            }()
+
+            do {
+                let target = try JSONDecoder().decode(DefaultTarget.self, from: json!)
                 XCTAssertEqual(target.value, testCase.output)
             } catch {
                 XCTFail(error.localizedDescription)


### PR DESCRIPTION
SeeAlso: https://www.swiftbysundell.com/tips/default-decoding-values/

support for optional value, and default decoding values

Decoding model
```swift
struct User: Decodable {
    @ForcibleString var fullName: String
    @ForcibleString.Option var nickName: String?
    @ForcibleDefault.EmptyString var petName: String
}
```

json
```json
{
    "fullName": 123,
}
```

```swift
do {
    let user = try JSONDecoder().decode(User.self, from: json!)
    print(user) // User(_fullName: 123, _nickName: nil, _petName: "")
} catch {
    print(error)
}
```